### PR TITLE
Make sure reject or resolved RN callback is called at most once

### DIFF
--- a/android/src/main/java/com/rnfingerprint/DialogResultHandler.java
+++ b/android/src/main/java/com/rnfingerprint/DialogResultHandler.java
@@ -16,16 +16,25 @@ public class DialogResultHandler implements FingerprintDialog.DialogResultListen
     @Override
     public void onAuthenticated() {
       FingerprintAuthModule.inProgress = false;
-      successCallback.invoke("Successfully authenticated.");
+      if (successCallback != null) {
+        successCallback.invoke("Successfully authenticated.");
+        errorCallback = successCallback = null;
+      }
     }
     @Override
     public void onError(String errorString) {
       FingerprintAuthModule.inProgress = false;
-      errorCallback.invoke(errorString);
+      if (errorCallback != null) {
+        errorCallback.invoke(errorString);
+        errorCallback = successCallback = null;
+      }
     }
     @Override
     public void onCancelled() {
       FingerprintAuthModule.inProgress = false;
-      errorCallback.invoke("cancelled");
+      if (errorCallback != null) {
+        errorCallback.invoke("cancelled");
+        errorCallback = successCallback = null;
+      }
     }
 }


### PR DESCRIPTION
This was a frequent cause of crashes. For some reason the callbacks were called multiple times which is not allowed and was causing the app to crash