### PR TITLE
Add error handling for samsung

### DIFF
--- a/android/src/main/java/com/rnfingerprint/FingerprintAuthModule.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintAuthModule.java
@@ -53,14 +53,22 @@ public class FingerprintAuthModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void isSupported(Callback reactErrorCallback, Callback reactSuccessCallback) {
-    keyguardManager =
-            (KeyguardManager) getCurrentActivity().getSystemService(Context.KEYGUARD_SERVICE);
-    fingerprintManager =
-            (FingerprintManager) getCurrentActivity().getSystemService(Context.FINGERPRINT_SERVICE);
-    if(!isFingerprintAuthAvailable()) {
-      reactErrorCallback.invoke("Not supported.");
-    } else {
-      reactSuccessCallback.invoke("Is supported.");
+    if (getCurrentActivity() != null) {
+      keyguardManager =
+              (KeyguardManager) getCurrentActivity().getSystemService(Context.KEYGUARD_SERVICE);
+      fingerprintManager =
+              (FingerprintManager) getCurrentActivity().getSystemService(Context.FINGERPRINT_SERVICE);
+      if(!isFingerprintAuthAvailable()) {
+        reactErrorCallback.invoke("Not supported.");
+      } else {
+        reactSuccessCallback.invoke("Is supported.");
+      }
+    }
+    else {
+      // in some cases getCurrentActivity() might return null. So instead NullPointerExcpetion, let
+      // just default back to touch id not supported...
+      // https://app.bugsnag.com/chime/react-native/errors/5aba69a7282944001b1ebf1f
+      reactErrorCallback.invoke("Not supported.");  
     }
     return ;
   }

--- a/android/src/main/java/com/rnfingerprint/FingerprintAuthModule.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintAuthModule.java
@@ -57,9 +57,9 @@ public class FingerprintAuthModule extends ReactContextBaseJavaModule {
     fingerprintManager =
             (FingerprintManager) getReactApplicationContext().getSystemService(Context.FINGERPRINT_SERVICE);
     if(!isFingerprintAuthAvailable()) {
-        reactErrorCallback.invoke("Not supported.");
+      reactErrorCallback.invoke("Not supported.");
     } else {
-        reactSuccessCallback.invoke("Is supported.");
+      reactSuccessCallback.invoke("Is supported.");
     }
     
     return ;

--- a/android/src/main/java/com/rnfingerprint/FingerprintAuthModule.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintAuthModule.java
@@ -37,7 +37,6 @@ import java.security.InvalidKeyException;
 import java.security.KeyStoreException;
 import java.security.UnrecoverableKeyException;
 
-
 public class FingerprintAuthModule extends ReactContextBaseJavaModule {
 
   public static boolean inProgress = false;
@@ -53,23 +52,16 @@ public class FingerprintAuthModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void isSupported(Callback reactErrorCallback, Callback reactSuccessCallback) {
-    if (getCurrentActivity() != null) {
-      keyguardManager =
-              (KeyguardManager) getCurrentActivity().getSystemService(Context.KEYGUARD_SERVICE);
-      fingerprintManager =
-              (FingerprintManager) getCurrentActivity().getSystemService(Context.FINGERPRINT_SERVICE);
-      if(!isFingerprintAuthAvailable()) {
+    keyguardManager =
+            (KeyguardManager) getReactApplicationContext().getSystemService(Context.KEYGUARD_SERVICE);
+    fingerprintManager =
+            (FingerprintManager) getReactApplicationContext().getSystemService(Context.FINGERPRINT_SERVICE);
+    if(!isFingerprintAuthAvailable()) {
         reactErrorCallback.invoke("Not supported.");
-      } else {
+    } else {
         reactSuccessCallback.invoke("Is supported.");
-      }
     }
-    else {
-      // in some cases getCurrentActivity() might return null. So instead NullPointerExcpetion, let
-      // just default back to touch id not supported...
-      // https://app.bugsnag.com/chime/react-native/errors/5aba69a7282944001b1ebf1f
-      reactErrorCallback.invoke("Not supported.");  
-    }
+    
     return ;
   }
 

--- a/android/src/main/java/com/rnfingerprint/FingerprintHandler.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintHandler.java
@@ -31,7 +31,7 @@ public class FingerprintHandler extends FingerprintManager.AuthenticationCallbac
                     && mFingerprintManager.isHardwareDetected()
                     && mFingerprintManager.hasEnrolledFingerprints();
         }
-        catch(SecurityException ex) {
+        catch (SecurityException ex) {
             // this catch is due to issues with Samsung devices
             // like here: https://stackoverflow.com/questions/37780080/android-fingerprints-hasenrolledfingerprints-triggers-exception-on-some-samsung 
             return false;

--- a/android/src/main/java/com/rnfingerprint/FingerprintHandler.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintHandler.java
@@ -8,6 +8,8 @@ import android.os.CancellationSignal;
 import android.support.v4.app.ActivityCompat;
 import android.widget.Toast;
 
+import java.lang.SecurityException;
+
 public class FingerprintHandler extends FingerprintManager.AuthenticationCallback {
 
     private CancellationSignal cancellationSignal;
@@ -29,9 +31,9 @@ public class FingerprintHandler extends FingerprintManager.AuthenticationCallbac
                     && mFingerprintManager.isHardwareDetected()
                     && mFingerprintManager.hasEnrolledFingerprints();
         }
-        catch(java.lang.SecurityException ex) {
-            // this catch is due to issues with Samsung devices.
-            // https://app.bugsnag.com/chime/react-native/errors/5ac7132bca857f001a46f859
+        catch(SecurityException ex) {
+            // this catch is due to issues with Samsung devices
+            // like here: https://stackoverflow.com/questions/37780080/android-fingerprints-hasenrolledfingerprints-triggers-exception-on-some-samsung 
             return false;
         }
     }

--- a/android/src/main/java/com/rnfingerprint/FingerprintHandler.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintHandler.java
@@ -24,9 +24,16 @@ public class FingerprintHandler extends FingerprintManager.AuthenticationCallbac
     }
 
     public boolean isFingerprintAuthAvailable() {
-        return (android.os.Build.VERSION.SDK_INT >= 23)
-                && mFingerprintManager.isHardwareDetected()
-                && mFingerprintManager.hasEnrolledFingerprints();
+        try {
+            return (android.os.Build.VERSION.SDK_INT >= 23)
+                    && mFingerprintManager.isHardwareDetected()
+                    && mFingerprintManager.hasEnrolledFingerprints();
+        }
+        catch(java.lang.SecurityException ex) {
+            // this catch is due to issues with Samsung devices.
+            // https://app.bugsnag.com/chime/react-native/errors/5ac7132bca857f001a46f859
+            return false;
+        }
     }
 
     public void startAuth(FingerprintManager.CryptoObject cryptoObject) {


### PR DESCRIPTION
Try to fix two issues from busnag:
- [Lack of current activity](https://app.bugsnag.com/chime/react-native/errors/5aba69a7282944001b1ebf1f) - I could not reproduce it, but this is not very common issue, and defaulting to PIN code should not hurt very much (at least, I don't know what better we can do in such case...)
 - [Unable to access FingerPrint sensor on various Samsung devices](https://app.bugsnag.com/chime/react-native/errors/5ac7132bca857f001a46f859)  - I don't know why this happen. I've tried to reproduce it, but I guess this has something to do with KNOX (or its newer versions). Bug report claims app needs `INTERACT_ACROSS_USERS`, but this could not be granted for regular Play Store app. So if we don't have required permissions, let's default back to PIN.